### PR TITLE
Kyanjo/friction inversion

### DIFF
--- a/applications/issm_model/examples/ISMIP_Choi/_issm_enkf.py
+++ b/applications/issm_model/examples/ISMIP_Choi/_issm_enkf.py
@@ -220,7 +220,8 @@ def generate_nurged_state(**kwargs):
     with h5py.File(bed_kriging_file, 'r') as f:
         bed_field = f['bed_ens'][...]
 
-    bed_field = np.mean(bed_field, axis=0)
+    # bed_field = np.mean(bed_field, axis=0)
+    bed_field = bed_field[0, :]
 
 
     # import netCDF4
@@ -240,7 +241,7 @@ def generate_nurged_state(**kwargs):
     friction_bed_filename = f'{icesee_path}/{data_path}/friction_bed_{ens_id}.h5'
     with h5py.File(friction_bed_filename, 'w', driver='mpio', comm=comm) as f:
         # -- write the friction field
-        # f.create_dataset('coefficient', data=friction_field)
+        f.create_dataset('coefficient', data=friction_field)
         # -- write the bed field
         f.create_dataset('bed', data=bed_field)
 
@@ -408,7 +409,7 @@ def initialize_ensemble(ens, **kwargs):
     friction_bed_filename = f'{icesee_path}/{data_path}/friction_bed_{ens_id}.h5'
     with h5py.File(friction_bed_filename, 'w', driver='mpio', comm=comm) as f:
         # -- write the friction field
-        # f.create_dataset('coefficient', data=friction_field)
+        f.create_dataset('coefficient', data=friction_field)
         # -- write the bed field
         f.create_dataset('bed', data=bed_field)
     #*-----------------------

--- a/applications/issm_model/examples/ISMIP_Choi/params.yaml
+++ b/applications/issm_model/examples/ISMIP_Choi/params.yaml
@@ -26,14 +26,14 @@ enkf-parameters:
   # Ensemble Kalman Filter parameters
   Nens: 50                      # Number of ensemble members (paper uses 50)
   freq_obs: 4 #4                 # Frequency of observations (annual, as per paper)
-  obs_max_time: 48          # Maximum time for observations (30 years)
+  obs_max_time: 44          # Maximum time for observations (30 years)
   obs_start_time: 0            # Start time for observations (start of simulation)
 
   generate_synthetic_obs: 1  # Generate synthetic observations for testing
   generate_true_state:    0  # Generate true state for synthetic observations
   generate_nurged_state:    0   # Generate nudged state for synthetic observations
   initialize_ensemble: 1
-  initial_spread_factor: 1.0
+  initial_spread_factor: 1.25
   sequential_ensemble_initialization: 0
   use_ensemble_pertubations: 0
 
@@ -56,11 +56,11 @@ enkf-parameters:
   bed_obs_stride: 4000          # Spacing of bedrock elevation observations (30 km)
 
   # Statistical parameters
-  sig_obs: [0, 2.8, 3.0, 1.5, 1.5,0]              # Observation error std dev: 5 m for H, 10 m/yr for Vx, Vy (paper)
-  sig_Q: [0.08, 0.08, 0.08, 0.01, 0.01,0.01]          # Process noise std dev (adjusted for H, Vx, Vy)
+  sig_obs: [0, 2.5, 3.0, 1.5, 1.5,0]              # Observation error std dev: 5 m for H, 10 m/yr for Vx, Vy (paper)
+  sig_Q: [0.08, 0.05, 0.08, 0.01, 0.01,0.01]          # Process noise std dev (adjusted for H, Vx, Vy)
   # length_scale: [300,220,180,150,320,250]               # Length scale for covariance (5 km for friction, per paper)
   # length_scale: [212,218,213,205, 212]               # Length scale for covariance (5 km for bed topography, per paper)
-  length_scale: [95,94,95,90, 95,95] 
+  length_scale: [88,85,90,85, 88,85]               # Length scale for covariance (2 km for bed topography, adjusted for resolution)
 
   seed: 42                       # Seed for random number generator
   inflation_factor: 1.0       # Inflation factor (optimal range 1.10–1.18 from paper)

--- a/applications/issm_model/examples/ISMIP_Choi/read_results.m
+++ b/applications/issm_model/examples/ISMIP_Choi/read_results.m
@@ -1,538 +1,634 @@
 %% -----------------------------------------------------------
-% @author: 	Brian Kyanjo
-% @date: 		2025-04-30
-% @brief: 	Reads and plot results from both ISSM and ICESEE
+% @author:  Brian Kyanjo
+% @date:    2025-06-30
+% @brief:   Reads and plots results from both ISSM and ICESEE
 % ------------------------------------------------------------
 
-close all; clear all
+close all; clearvars; clear all
 
-% data_file_paths='data_0/_modelrun_datasets';
-% data_file_paths='data_1';
-% data_file_paths='_modelrun_datasets';
-global data_file_paths 
+global data_file_paths nvar
 data_file_paths = '_modelrun_datasets';
-
-
-% time steps
-% k_array = [10, 30, 50, 80,120];  % multiple time steps
-k_array=[25, 45, 60, 80, 101, 137, 270];
-% k_array=[30, 40, 80,160, 180];
-% k_array=[20, 80,120, 160, 240, 350, 450];
-% k_array=[1];
-dt = 0.2;
-global nvar;
 nvar = 6;
 
-make_plots = 0;
-make_multi_plots = 1;
-k = 65;
-% k=28;
+% ---------------- user toggles ----------------
+make_plots       = 0;
+make_multi_plots = 0;   % <-- ON (restored)
+frames_plot      = 0;
 
-% Load the essential data
+% ---------------- time steps ------------------
+% k_array = [1, 20,  50, 80, 120, 170, 220];
+k_array= [20,80, 120, 160, 190]+1;
+% k_array = [20, 50, 80, 120, 160, 200, 240, 320] +1;
+% k_array = [20, 80, 160, 200, 250, 300]+1;
+dt      = 0.2;
+
+% ---------------- Load essentials --------------
 results_dir = 'results';
 filter_type = 'true-wrong';
 file_path   = fullfile(results_dir, sprintf('%s-issm.h5', filter_type));
-t           = h5read(file_path,'/t');
-ind_m       = h5read(file_path,'/obs_index');
-tm_m        = h5read(file_path,'/obs_max_time');
-run_mode    = h5read(file_path,'/run_mode');
+t        = h5read(file_path,'/t'); 
+ind_m    = h5read(file_path,'/obs_index'); 
+tm_m     = h5read(file_path,'/obs_max_time'); 
+run_mode = h5read(file_path,'/run_mode'); 
 
-% load the true and nurged states
-file_path            = fullfile(data_file_paths, 'true_nurged_states.h5');
-model_true_state     = h5read(file_path,'/true_state')';
-model_nurged_state   = h5read(file_path, '/nurged_state')';
+% true / wrong (nurged)
+file_path          = fullfile(data_file_paths, 'true_nurged_states.h5');
+model_true_state   = h5read(file_path,'/true_state')';
+model_nurged_state = h5read(file_path,'/nurged_state')';
 
-% load observation data
-file_path  = fullfile(data_file_paths, 'synthetic_obs.h5');
-w          = h5read(file_path, '/hu_obs')'; 
+% obs (kept)
+file_path = fullfile(data_file_paths, 'synthetic_obs.h5');
+w = h5read(file_path, '/hu_obs')'; 
 
-% load the ensemble data
+% ensemble mean
 file_path         = fullfile(data_file_paths, 'icesee_ensemble_data.h5');
-ensemble_vec_full = h5read(file_path, '/ensemble'); 
 ensemble_vec_mean = h5read(file_path, '/ensemble_mean')';
 
-% Or read from .mat files (from the ISSM side)
-% file_path_true= fullfile("issm_data","true_state.mat");
-% file_path_nurged= fullfile("issm_data","nurged_state.mat");
-% md_true_= loadmodel(file_path_true);
-% md_nurged_= loadmodel(file_path_nurged);
+% ISSM model template
+md = loadmodel(fullfile("data","ISMIP.Parameterization1.mat"));
+md_true   = md;
+md_nurged = md;
+md_ens    = md;
 
-% Process and plot
-[ndim, nt] = size(model_true_state);
-num_steps = nt - 1;
-var_inputs = ['thickness', 'Vx', 'Vy', 'friction_coefficient', 'bed_topography'];
-hdim = floor(ndim / nvar);  % dimension of one variable
-
-% file_path   = fullfile("data", "ISMIP_initial_data.mat");
-% file_path   = fullfile("data", "ISMIP.Parameterization1.mat");
-file_path   = fullfile("data", "ISMIP.Parameterization1.mat");
-md = loadmodel(file_path);
-md_true = md; md_nurged = md;
-md_mean = md; md_ens = md;
-% dt = t(2) - t(1);
-% dt = 0.25;
-
-k_gl = 150;             % choose one of your k_array entries
-[md_true, md_nurged, md_ens] = setup_model_states(k_gl, dt, ...
+% ---------------- GL evolution plot ------------
+plot_gl_on_bed_evolution( ...
+    k_array, dt, ...
     model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    md_true, md_nurged, md_ens, md);
+    md_true, md_nurged, md_ens, md, ...
+    'geometry.thickness', 'Thickness', 'm');
 
-plot_gl_on_bed(md_true, md_nurged, md_ens, round((k_gl-1)*dt));
-
-% for k_gl = 1:499
-%     % k_gl = 20;             % choose one of your k_array entries
-%     [md_true, md_nurged, md_ens] = setup_model_states(k_gl, dt, ...
-%         model_true_state, model_nurged_state, ensemble_vec_mean, ...
-%         md_true, md_nurged, md_ens, md);
-% 
-%     plot_gl_on_bed(md_true, md_nurged, md_ens, round((k_gl-1)*dt));
-% end
-
-frames_plot=0;
-
-make_gl_movie = 1;           % set true if you want an mp4
-frame_stride  = 10;              % plot every 20th step (adjust)
-if frames_plot
-    if make_gl_movie
-        v = VideoWriter('velocity_gl_evolution.mp4','MPEG-4');
-        v.FrameRate = 8;
-        open(v);
-    end
-    
-    for k_gl = 1:frame_stride:nt
-        % Build true / nurged / ensemble models at this time
-        [md_true_k, md_nurged_k, md_ens_k] = setup_model_states( ...
-            k_gl, dt, ...
-            model_true_state, model_nurged_state, ensemble_vec_mean, ...
-            md_true, md_nurged, md_ens, md);
-    
-        % Just in case: cheap diagnostic to see if GLs differ at all
-        phi_true   = md_true_k.mask.ocean_levelset;
-        phi_nurged = md_nurged_k.mask.ocean_levelset;
-        phi_ens    = md_ens_k.mask.ocean_levelset;
-        fprintf('k=%4d (t = %6.2f yr): max|true-nurged| = %.3e, max|true-ens| = %.3e\n', ...
-                k_gl, (k_gl-1)*dt, ...
-                max(abs(phi_true - phi_nurged)), ...
-                max(abs(phi_true - phi_ens)));
-    
-        % Plot this timestep
-        plot_velocity_with_gl(md_true_k, md_nurged_k, md_ens_k, (k_gl-1)*dt);
-        drawnow;
-    
-        if make_gl_movie
-            frame = getframe(gcf);
-            writeVideo(v, frame);
-        else
-            pause(0.15);   % slow down when just inspecting
-        end
-    end
-    
-    if make_gl_movie
-        close(v);
-    end
-end
-
-if make_multi_plots 
-    % %{ % Thickness difference plots
-    plot_var_diff(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.thickness', 'Thicknes', 'm');
-    % 
-    %  % thickness plot evolution
-    plot_var_evolution(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.thickness', 'Thickness', 'm');
-    % 
-    % % base  
-    % plot_var_diff(k_array, dt, ...
-    %     model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    %     md_true, md_nurged, md_ens, md, ...
-    %     'geometry.base', 'Base', 'm');
-    % 
-    %  % thickness plot evolution
-    % plot_var_evolution(k_array, dt, ...
-    %     model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    %     md_true, md_nurged, md_ens, md, ...
-    %     'geometry.base', 'Base', 'm');
-    % 
-    plot_var_diff(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.surface', 'Surface', 'm');
-    % 
-    %  % thickness plot evolution
-    plot_var_evolution(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.surface', 'Surface', 'm');
-    % 
-        % velocity evolution plots
-    plot_var_evolution(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'initialization.vel', 'Velocity', 'm/s');
-    % 
-    plot_var_diff(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'initialization.vel', 'Velocity', 'm/s'); %}
-        % bed topography evolution plots        
-    plot_var_evolution(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.bed', 'Bed Elevation', 'm');
-    plot_var_diff(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'geometry.bed', 'Bed', 'm');
-    
-        % friction coefficient evolution plots  
-    plot_var_evolution(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'friction.coefficient', 'Friction Coefficient', '');
-    plot_var_diff(k_array, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
-        md_true, md_nurged, md_ens, md, ...
-        'friction.coefficient', 'Friction', 'm');
-end 
-
-if make_plots
+% ---------------- multi-plots restored ----------
+if make_multi_plots
     % thickness
-    [md_true, md_nurged, md_ens] = setup_model_states(k, dt, ...
-            model_true_state, model_nurged_state, ensemble_vec_mean, ...
-            md_true, md_nurged, md_ens, md);
-    plot_triptych(md_true, md_nurged, md_ens, ...
-                'geometry.thickness', sprintf('Ice Thickness after %d years', round((k-1)*dt)), parula, 'm');  
-    plot_triptych(md_true, md_nurged, md_ens, ...
-                'geometry.surface', sprintf('Ice Surface after %d years', round((k-1)*dt)), parula, 'm');  
-    % velocity              
-    plot_triptych(md_true, md_nurged, md_ens, ...
-                'initialization.vel', sprintf('Ice Velocity after %d years', round((k-1)*dt)), parula, 'm/s');   
-    % bed topography
-    plot_triptych(md_true, md_nurged, md_ens, ...
-                'geometry.bed', sprintf('Bed Elevation after %d years', round((k-1)*dt)), parula, 'm');
-    %
-    % Frcition coefficient
-    plot_triptych(md_true, md_nurged, md_ens, ...
-                'friction.coefficient', sprintf('Friction Coefficient after %d years', round((k-1)*dt)), parula, '');
-    %
-    % % grounding line
-    % plot_triptych(md_true, md_nurged, md_ens, ...
-    %               'results.TransientSolution(499).MaskOceanLevelset', ...
-    %               'Grounding Line', gray, '');
-    % plot_triptych(md_true, md_nurged, md_ens, ...
-    %             'mask.ocean_levelset', ...
-    %             sprintf('Grounding Line after %d years', round((k-1)*dt)), parula, '');
-end
-% create a movie for the groundingline for every 10 yrs
-% Setup video writer (optional)
-make_movie = false;
-if make_movie
-    if make_movie
-        v = VideoWriter('groundingline_triptych.mp4','MPEG-4');
-        v.FrameRate = 10;  % frames per second
-        open(v);
-    end
+    plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.thickness', 'Thickness', 'm');
+    plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.thickness', 'Thickness', 'm');
 
-    % Precompute density ratio
-    di = md.materials.rho_ice / md.materials.rho_water;
+    % surface
+    plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.surface', 'Surface', 'm');
+    plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.surface', 'Surface', 'm');
 
-    for k = 1:20:500
-        
-        % Update ensemble model from state vector
-        md_ens.geometry.bed        = ensemble_vec_mean(hdim+1:2*hdim, k);
-        md_ens.geometry.thickness  = ensemble_vec_mean(1:hdim, k);
-        md_ens.friction.coefficient= ensemble_vec_mean(2*hdim+1:3*hdim, k);
+    % velocity
+    plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'initialization.vel', 'Velocity', 'm/s');
+    plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'initialization.vel', 'Velocity', 'm/s');
 
-        % Compute flotation mask for ensemble
-        md_ens.mask.ocean_levelset = md_ens.geometry.thickness + md_ens.geometry.bed/di;
+    % bed
+    plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.bed', 'Bed Elevation', 'm');
+    plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'geometry.bed', 'Bed', 'm');
 
-        % Fetch true & nudged grounding lines
-        md_true.mask.ocean_levelset   = md_true_.results.TransientSolution(k).MaskOceanLevelset;
-        md_nurged.mask.ocean_levelset = md_nurged_.results.TransientSolution(k).MaskOceanLevelset;
-
-        % Plot triptych
-        plot_triptych(md_true, md_nurged, md_ens, ...
-                    'mask.ocean_levelset', ...
-                    sprintf('Grounding Line after %d years', round((k-1)*0.5)), ...
-                    parula, '');
-
-        drawnow;
-
-        % Capture frame if making movie
-        if make_movie
-            frame = getframe(gcf);
-            writeVideo(v, frame);
-        else
-            pause(dt); % interactive view
-        end
-    end
-
-    if make_movie
-        close(v);
-    end
+    % friction
+    plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'friction.coefficient', 'Friction Coefficient', '');
+    plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md, 'friction.coefficient', 'Friction', '');
 end
 
-
-%% -- helper functions -- %%
-function plot_var_diff(k_array, dt, ...
-    model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    md_true, md_nurged, md_ens, md, field, field_title, units)
-    % =========================================================================
-    % plot_var_diff
-    % Automatically adapts the number of subplots to the length of k_array.
-    % =========================================================================
-
-    if nargin < 12, units = ''; end
-    units_str = iff(~isempty(units), [' (' units ')'], '');
-    nk = length(k_array);
-    nrows = 2 + nk;  % (a) True + (b) No assimilation + (c...e) Assim steps
-
-    figure('Position',[100 100 1000 150 + 150*nrows]); clf;
-
-    % ---- Compute global colour limits across all requested steps ----
-    all_data = [];
-
-    for k = [1, k_array]          % include the true (initial) state
-        [md_true_tmp, md_nurged_tmp, md_ens_tmp] = setup_model_states(k, dt, ...
-            model_true_state, model_nurged_state, ensemble_vec_mean, ...
-            md_true, md_nurged, md_ens, md);
-        data_tmp = get_nested_field(md_ens_tmp, field);
-        all_data = [all_data; data_tmp(:)];
-        % Also include true state for diff limits
-        data_true_tmp = get_nested_field(md_true_tmp, field);
-        all_data = [all_data; data_true_tmp(:)];
-        % nureged state for diff limits
-        % data_nurged_tmp = get_nested_field(md_nurged_tmp, field);
-        % all_data = [all_data; data_nurged_tmp(:)];
-    end
-
-    cmin = min(all_data);
-    cmax = max(all_data);
-   
-    clear all_data
-
-    % (a) True field
-    [md_true, md_nurged, md_ens] = setup_model_states(1, dt, ...
+% ---------------- optional single triptych -------
+if make_plots
+    k = k_array(end);
+    [md_true_k, md_nurged_k, md_ens_k] = setup_model_states(k, dt, ...
         model_true_state, model_nurged_state, ensemble_vec_mean, ...
         md_true, md_nurged, md_ens, md);
-    data_true = get_nested_field(md_true, field);
-    data_ens  = get_nested_field(md_ens, field);
-    data_nurged = get_nested_field(md_nurged, field);
-    % cmin = min([data_true(:); data_ens(:)]);
-    % cmax = max([data_true(:); data_ens(:)]);
-    plotmodel(md_true, 'data', data_true, ...
-        'title', sprintf('(a) True %s', field_title), ...
-        'subplot', [nrows, 1, 1], 'caxis', [cmin cmax], 'colorbar', 'off');
 
-    % (b) No assimilation − True
-    % diff_noassim = data_ens - data_true;
+    plot_triptych(md_true_k, md_nurged_k, md_ens_k, ...
+        'geometry.thickness', sprintf('Ice Thickness after %.1f years', (k-1)*dt), parula, 'm');
+    plot_triptych(md_true_k, md_nurged_k, md_ens_k, ...
+        'geometry.surface', sprintf('Ice Surface after %.1f years', (k-1)*dt), parula, 'm');
+    plot_triptych(md_true_k, md_nurged_k, md_ens_k, ...
+        'geometry.bed', sprintf('Bed after %.1f years', (k-1)*dt), parula, 'm');
+    plot_triptych(md_true_k, md_nurged_k, md_ens_k, ...
+        'mask.ocean_levelset', sprintf('Grounding Line after %.1f years', (k-1)*dt), parula, 'm');
     
-    eps0 = 0.001 * max(abs(data_true(:)));
-    % diff_noassim = (data_ens - data_true)./(abs(data_true) + eps0);
-    [md_true, md_nurged, md_ens] = setup_model_states(1, dt, ...
-    model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    md_true, md_nurged, md_ens, md);
-    data_true = get_nested_field(md_true, field);
-    data_ens  = get_nested_field(md_ens, field);
-    data_nurged = get_nested_field(md_nurged, field);
-    diff_noassim = (data_ens - data_true); 
-    % diff_noassim = abs(data_ens - data_true)./(abs(data_true));
-    maxAbs_noassim = max(abs(diff_noassim(:)));
-    maxAbs= maxAbs_noassim;
-    % maxAbs_noassim = 2;
-    plotmodel(md_ens, 'data', diff_noassim, ...
-        'title', '(b) No assimilation − True', ...
-        'subplot', [nrows, 1, 2], 'caxis', [-maxAbs_noassim maxAbs_noassim], 'colorbar', 'off');
+end
 
-    % (c...): Assimilation differences at each k
-    for idx = 1:nk
-        label = sprintf('(%c)', 'b' + idx);
-        k = k_array(idx);
-        [md_true, md_nurged, md_ens] = setup_model_states(k, dt, ...
+%% ========================================================================
+%%  Helper functions
+%% ========================================================================
+
+function [md_true, md_nurged, md_ens] = setup_model_states( ...
+    k, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    md_true, md_nurged, md_ens, md)
+% Initialize the true, wrong (nurged), and ensemble-mean models at index k.
+    global nvar
+    ndim = size(model_true_state,1);
+    hdim = ndim / nvar;
+    di   = md.materials.rho_ice / md.materials.rho_water;
+
+    % --- TRUE ---
+    H  = model_true_state(1:hdim, k);
+    S  = model_true_state(hdim+1:2*hdim, k);
+    B  = S - H;
+    Vx = model_true_state(2*hdim+1:3*hdim, k);
+    Vy = model_true_state(3*hdim+1:4*hdim, k);
+    Vel= hypot(Vx, Vy);
+    bed= model_true_state(4*hdim+1:5*hdim, k);
+    fc = model_true_state(5*hdim+1:6*hdim, k);
+
+    md_true.geometry.thickness      = H;
+    md_true.geometry.surface        = S;
+    md_true.geometry.base           = B;
+    md_true.geometry.bed            = bed;
+    md_true.initialization.vx       = Vx;
+    md_true.initialization.vy       = Vy;
+    md_true.initialization.vel      = Vel;
+    md_true.friction.coefficient    = fc;
+    md_true.mask.ocean_levelset     = H + bed/di;
+
+    % --- WRONG (nurged) ---
+    H  = model_nurged_state(1:hdim, k);
+    S  = model_nurged_state(hdim+1:2*hdim, k);
+    B  = S - H;
+    Vx = model_nurged_state(2*hdim+1:3*hdim, k);
+    Vy = model_nurged_state(3*hdim+1:4*hdim, k);
+    Vel= hypot(Vx, Vy);
+    bed= model_nurged_state(4*hdim+1:5*hdim, k);
+    fc = model_nurged_state(5*hdim+1:6*hdim, k);
+
+    md_nurged.geometry.thickness    = H;
+    md_nurged.geometry.surface      = S;
+    md_nurged.geometry.base         = B;
+    md_nurged.geometry.bed          = bed;
+    md_nurged.initialization.vx     = Vx;
+    md_nurged.initialization.vy     = Vy;
+    md_nurged.initialization.vel    = Vel;
+    md_nurged.friction.coefficient  = fc;
+    md_nurged.mask.ocean_levelset   = H + bed/di;
+
+    % --- ENSEMBLE MEAN ---
+    H  = ensemble_vec_mean(1:hdim, k);
+    S  = ensemble_vec_mean(hdim+1:2*hdim, k);
+    B  = S - H;
+    Vx = ensemble_vec_mean(2*hdim+1:3*hdim, k);
+    Vy = ensemble_vec_mean(3*hdim+1:4*hdim, k);
+    Vel= hypot(Vx, Vy);
+    bed= ensemble_vec_mean(4*hdim+1:5*hdim, k);
+    fc = ensemble_vec_mean(5*hdim+1:6*hdim, k);
+
+    md_ens.geometry.thickness       = H;
+    md_ens.geometry.surface         = S;
+    md_ens.geometry.base            = B;
+    md_ens.geometry.bed             = bed;
+    md_ens.initialization.vx        = Vx;
+    md_ens.initialization.vy        = Vy;
+    md_ens.initialization.vel       = Vel;
+    md_ens.friction.coefficient     = fc;
+    md_ens.mask.ocean_levelset      = H + bed/di;
+end
+
+function out = get_nested_field(s, field)
+% Access nested fields with dot notation: e.g. 'geometry.base'
+    parts = strsplit(field,'.');
+    out = s;
+    for i = 1:numel(parts)
+        tok = parts{i};
+        t = regexp(tok,'(.+)\((\d+)\)$','tokens');
+        if ~isempty(t)
+            out = out.(t{1}{1})(str2double(t{1}{2}));
+        else
+            out = out.(tok);
+        end
+    end
+end
+
+function y = iff(c,a,b)
+    if c, y=a; else, y=b; end
+end
+
+function cmap = redblue(n)
+    if nargin<1, n=256; end
+    m = n/2;
+    r=[linspace(0,1,m) ones(1,m)];
+    g=[linspace(0,1,m) linspace(1,0,m)];
+    b=[ones(1,m) linspace(1,0,m)];
+    cmap=[r(:) g(:) b(:)];
+end
+
+%% ---------------- GL evolution plot (robust) ----------------
+function plot_gl_on_bed_evolution( ...
+    k_array, dt, ...
+    model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    md_true, md_nurged, md_ens, md, ...
+    bg_field, bg_title, units)
+
+    if nargin < 11 || isempty(bg_field), bg_field = 'initialization.vel'; end
+    if nargin < 12 || isempty(bg_title), bg_title = 'Background'; end
+    if nargin < 13, units = ''; end
+    units_str = iff(~isempty(units), [' (' units ')'], '');
+
+    nk    = numel(k_array);
+    nrows = nk;
+
+    figure('Position',[100 100 1000 (180 + 150*nrows)]); clf;
+
+    % ---- global color limits from TRUE background ----
+    all_data = [];
+    for kk = k_array
+        [md_true_k, ~, ~] = setup_model_states(kk, dt, ...
             model_true_state, model_nurged_state, ensemble_vec_mean, ...
             md_true, md_nurged, md_ens, md);
-        true_field = get_nested_field(md_true, field);
-        ens_field  = get_nested_field(md_ens, field);
-        
-        eps0 = 0.001 * max(abs(true_field(:)));    % 1% of max for stabilization
-        % diff_data = (ens_field - true_field) ./ (abs(true_field) + eps0);
+        bg = get_nested_field(md_true_k, bg_field);
+        all_data = [all_data; bg(:)]; %
+    end
+    cmin = min(all_data);
+    cmax = max(all_data);
+    clear all_data
 
-        % diff_data = abs(get_nested_field(md_ens, field) - get_nested_field(md_true, field))./abs(get_nested_field(md_true, field));
-        diff_data = (get_nested_field(md_ens, field) - get_nested_field(md_true, field));
-        % diff_data = (get_nested_field(md_ens, field) - get_nested_field(md_true, field));
-        maxAbs = max(abs(diff_data(:)));
-        % maxAbs=2;
-        plotmodel(md_ens, 'data', diff_data, ...
-            'title', sprintf('%s Assimilated − True (after %.1f years)', label, round((k-1)*dt)), ...
-            'subplot', [nrows, 1, idx + 2], 'caxis', [-maxAbs maxAbs], 'colorbar', 'off');
+    % ---- GL grid resolution ----
+    Nx = 420; Ny = 70;
+
+    % ---- filtering knobs ----
+    minLen_true  = 3e4;
+    minLen_wrong = 3e4;
+    minLen_ens   = 3e4;
+    minArea      = 2;
+
+    keepLargestOnly_true  = true;
+    keepLargestOnly_wrong = true;
+    keepTopK_ens          = 4;   % allow 2 longest for ensemble (prevents “loss”)
+
+    for idx = 1:nk
+        k = k_array(idx);
+
+        [md_true_k, md_nurged_k, md_ens_k] = setup_model_states(k, dt, ...
+            model_true_state, model_nurged_state, ensemble_vec_mean, ...
+            md_true, md_nurged, md_ens, md);
+
+        bg = get_nested_field(md_true_k, bg_field);
+
+        plotmodel(md_true_k, 'data', bg, ...
+            'title', sprintf('(%c) %s + GLs (t = %.1f years)', ...
+                'a'+(idx-1), bg_title, (k-1)*dt), ...
+            'subplot', [nrows, 1, idx], ...
+            'caxis', [cmin cmax], ...
+            'colorbar', 'off');
+
+        ax = gca;
+
+        % prevent plotmodel objects appearing in legend
+        set(ax.Children, 'HandleVisibility','off');
+
+        % grid for contouring
+        x = md_true_k.mesh.x(:);
+        y = md_true_k.mesh.y(:);
+        xg = linspace(min(x), max(x), Nx);
+        yg = linspace(min(y), max(y), Ny);
+        [Xg, Yg] = meshgrid(xg, yg);
+
+        phi_true  = md_true_k.mask.ocean_levelset(:);
+        phi_wrong = md_nurged_k.mask.ocean_levelset(:);
+        phi_ens   = md_ens_k.mask.ocean_levelset(:);
+
+        % print diagnostic so you can confirm if ens truly loses sign change
+        fprintf('k=%d t=%.1f | ens[min,max]=[%.3e,%.3e]\n', ...
+            k, (k-1)*dt, min(phi_ens), max(phi_ens));
+
+        % linear + nearest extrap => NO NaN holes that break contour
+        F1 = scatteredInterpolant(x, y, phi_true,  'linear','nearest');
+        F2 = scatteredInterpolant(x, y, phi_wrong, 'linear','nearest');
+        F3 = scatteredInterpolant(x, y, phi_ens,   'linear','nearest');
+
+        Phi_true  = F1(Xg, Yg);
+        Phi_wrong = F2(Xg, Yg);
+        Phi_ens   = F3(Xg, Yg);
+
+        hold(ax,'on');
+        plot_gl_contour_filtered(Xg, Yg, Phi_true,  'k','-',  2.0, minLen_true,  minArea, keepLargestOnly_true,  1);
+        plot_gl_contour_filtered(Xg, Yg, Phi_wrong, 'r','-', 2.0, minLen_wrong, minArea, keepLargestOnly_wrong, 1);
+        plot_gl_contour_filtered(Xg, Yg, Phi_ens,   'c','-',  2.0, minLen_ens,   minArea, false,               keepTopK_ens);
+        hold(ax,'off');
     end
 
-    % Adjust layout
+    % ---- Layout: adaptive spacing ----
     axs = flipud(findall(gcf,'Type','axes'));
-    % --- Adaptive layout scaling ---
-    gap = 0.02;              % small positive gap
-    top = 0.95; bottom = 0.08;
-    available_height = top - bottom - (nrows-1)*gap;
-    height = available_height / nrows;
+    gap = 0.02; top = 0.95; bottom = 0.08;
+    avail = top - bottom - (nrows-1)*gap;
+    height = avail / nrows;
 
-    % if too small (many rows), expand figure height automatically
     if height < 0.05
         fig = gcf;
-        scale_factor = max(1, ceil(0.05 / height));  % ensure visible spacing
-        fig.Position(4) = fig.Position(4) * scale_factor;  % increase figure height
-        height = 0.05;  % set to minimum safe height
+        scale_factor = max(1, ceil(0.05 / height));
+        fig.Position(4) = fig.Position(4) * scale_factor;
+        height = 0.05;
     end
-
 
     for i = 1:nrows
         pos = [0.10, bottom+(nrows-i)*(height+gap), 0.70, height];
-        set(axs(i), 'Position', pos, 'FontWeight', 'bold', ...
-            'LineWidth', 1.2, 'Box', 'on', 'TickDir', 'out', ...
-            'Layer', 'top', 'FontSize', 11, 'TickLength',[0.005 0.005]);
-        ylabel(axs(i),'y (km)','FontWeight','bold');
+        set(axs(i), 'Position', pos, ...
+            'FontWeight','bold','LineWidth',1.2,'Box','on', ...
+            'TickDir','out','Layer','top','FontSize',11, ...
+            'TickLength',[0.005 0.005]);
+        ylabel(axs(i),'y (m)','FontWeight','bold');
         if i < nrows
             set(axs(i),'XTickLabel',[]);
         else
-            xlabel(axs(i),'x (km)','FontWeight','bold');
+            xlabel(axs(i),'x (m)','FontWeight','bold');
         end
     end
 
-    % Colorbars
-    cb1 = colorbar(axs(1), 'Position',[0.83 0.68 0.025 0.16]);
-    ylabel(cb1,[field_title units_str],'FontSize',12,'FontWeight','bold');
-    colormap(axs(1), parula);
-    for i = 2:nrows, colormap(axs(i), redblue(256)); end
-    cb2 = colorbar(axs(end), 'Position',[0.83 0.25 0.025 0.40]);
-    % ylabel(cb2,['Δ' field_title units_str],'FontSize',12,'FontWeight','bold');
-    ylabel(cb2,['Relative Error'],'FontSize',12,'FontWeight','bold');
+    % ---- Shared colorbar ----
+    for i = 1:nrows, colormap(axs(i), parula); end
+    cb = colorbar(axs(end), 'Position',[0.83 0.25 0.025 0.45]);
+    ylabel(cb, [bg_title units_str], 'FontSize',12,'FontWeight','bold');
+
+    % ---- Clean legend (proxy only) ----
+    ax0 = axs(1);
+    lg = legend(ax0);
+    if ~isempty(lg) && isvalid(lg), delete(lg); end
+
+    hold(ax0,'on');
+    p1 = plot(ax0, NaN, NaN, 'k-',  'LineWidth', 2.0);
+    p2 = plot(ax0, NaN, NaN, 'r-', 'LineWidth', 2.0);
+    p3 = plot(ax0, NaN, NaN, 'c-',  'LineWidth', 2.0);
+    lgd = legend(ax0, [p1 p2 p3], ...
+        {'True GL','No assimilation GL','Assimilated GL'}, ...
+        'Location','northwest','FontSize',10,'Box','on');
+    lgd.AutoUpdate = 'on';
+    % legend(ax0,'manual');
+    hold(ax0,'off');
+
     set(gcf,'Color','w');
 end
 
+function h = plot_gl_contour_filtered( ...
+    Xg, Yg, Phig, line_color, line_style, lw, minLen, minArea, keepLargestOnly, keepTopK)
 
-function plot_var_evolution(k_array, dt, ...
-    model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    if nargin < 6 || isempty(lw), lw = 2.0; end
+    if nargin < 7 || isempty(minLen), minLen = 2e4; end
+    if nargin < 8 || isempty(minArea), minArea = 0; end
+    if nargin < 9 || isempty(keepLargestOnly), keepLargestOnly = false; end
+    if nargin < 10 || isempty(keepTopK), keepTopK = 1; end
+
+    h = gobjects(0);
+
+    if ~all(isfinite(Phig(:)))
+        Phig(~isfinite(Phig)) = 1;
+    end
+
+    if min(Phig(:)) * max(Phig(:)) > 0
+        return; % no sign change => no GL
+    end
+
+    C = contourc(Xg(1,:), Yg(:,1), Phig, [0 0]);
+
+    segs  = {};
+    lens  = [];
+    areas = [];
+
+    kk = 1;
+    while kk < size(C,2)
+        npts = C(2,kk);
+        pts  = C(:, kk+1:kk+npts);
+        kk   = kk + npts + 1;
+
+        x = pts(1,:); y = pts(2,:);
+        L = sum(hypot(diff(x), diff(y)));
+
+        isClosed = hypot(x(1)-x(end), y(1)-y(end)) < 1e-6 + 0.02*max(1, mean(hypot(diff(x),diff(y))));
+        A = 0;
+        if isClosed
+            A = abs(polyarea(x, y));
+        end
+
+        segs{end+1}  = pts; %
+        lens(end+1)  = L;   %
+        areas(end+1) = A;   %
+    end
+
+    if isempty(segs), return; end
+
+    keep = true(1,numel(segs));
+    keep = keep & (lens >= minLen);
+
+    if minArea > 0
+        keep = keep & (areas >= minArea | areas == 0);
+    end
+
+    idx = find(keep);
+    if isempty(idx), return; end
+
+    [~, order] = sort(lens(idx), 'descend');
+    idx = idx(order);
+
+    if keepLargestOnly
+        idx = idx(1);
+    else
+        idx = idx(1:min(keepTopK, numel(idx)));
+    end
+
+    hold on
+    for i = 1:numel(idx)
+        pts = segs{idx(i)};
+        h(end+1) = plot(pts(1,:), pts(2,:), ...
+            'Color', line_color, 'LineStyle', line_style, 'LineWidth', lw); %
+    end
+end
+
+%% ---------------- multi-plot helpers (your style) ----------------
+function plot_var_diff(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
     md_true, md_nurged, md_ens, md, field, field_title, units)
-    % =========================================================================
-    % plot_var_evolution
-    % Automatically adapts subplot layout to number of k_array elements.
-    % =========================================================================
 
-    if nargin < 13, field_title = field; end
-    if nargin < 14, units = ''; end
+    if nargin < 12, units = ''; end
     units_str = iff(~isempty(units), [' (' units ')'], '');
-    nk = length(k_array);
+
+    nk    = length(k_array);
     nrows = 2 + nk;
 
     figure('Position',[100 100 1000 150 + 150*nrows]); clf;
 
-    % ---- Compute global colour limits across all requested steps ----
+    % global limits for absolute field (panel a)
     all_data = [];
-
-    % for k = [1, k_array]          % include the true (initial) state
-    for k = [k_array(end), k_array]
-        [md_true_tmp, md_nurged_tmp, md_ens_tmp] = setup_model_states(k, dt, ...
+    for k = [1, k_array]
+        [md_true_tmp, ~, md_ens_tmp] = setup_model_states(k, dt, ...
             model_true_state, model_nurged_state, ensemble_vec_mean, ...
             md_true, md_nurged, md_ens, md);
-        data_tmp = get_nested_field(md_ens_tmp, field);
-        all_data = [all_data; data_tmp(:)];
-        % Also include true state for diff limits
-        data_true_tmp = get_nested_field(md_true_tmp, field);
-        all_data = [all_data; data_true_tmp(:)];
-        % nureged state for diff limits
-        % data_nurged_tmp = get_nested_field(md_nurged_tmp, field);
-        % all_data = [all_data; data_nurged_tmp(:)];
+    
+        tmpT = get_nested_field(md_true_tmp, field);
+        tmpE = get_nested_field(md_ens_tmp,  field);
+    
+        all_data = [all_data; tmpT(:); tmpE(:)];
     end
-
     cmin = min(all_data);
     cmax = max(all_data);
     clear all_data
 
     % (a) True
-    [md_true, md_nurged, md_ens] = setup_model_states(k_array(end), dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    [md_true_k, ~, ~] = setup_model_states(1, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
         md_true, md_nurged, md_ens, md);
-    data_true = get_nested_field(md_true, field);
-    data_ens  = get_nested_field(md_ens, field);
-    data_nurged = get_nested_field(md_nurged, field);
-    % cmin = min([data_true(:); data_ens(:)]);
-    % cmax = max([data_true(:); data_ens(:)]);
-    plotmodel(md_true, 'data', data_true, ...
-        'title', sprintf('(a) True %s (after %.1f years)', field_title, round(k_array(end)-1)*dt), ...
-        'subplot', [nrows, 1, 1], 'caxis', [cmin cmax], 'colorbar', 'off');
+    data_true = get_nested_field(md_true_k, field);
+    plotmodel(md_true_k,'data',data_true,'title',sprintf('(a) True %s',field_title), ...
+        'subplot',[nrows,1,1],'caxis',[cmin cmax],'colorbar','off');
 
-    % (b) No assimilation
-    [md_true, md_nurged, md_ens] = setup_model_states(1, dt, ...
-        model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    % (b) No assimilation - True
+    [md_true_1, ~, md_ens_1] = setup_model_states(1, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
         md_true, md_nurged, md_ens, md);
-    data_true = get_nested_field(md_true, field);
-    data_ens  = get_nested_field(md_ens, field);
-    data_nurged = get_nested_field(md_nurged, field);
-    plotmodel(md_ens, 'data', data_ens, ...
-        'title', sprintf('(b) No assimilation %s', field_title), ...
-        'subplot', [nrows, 1, 2], 'caxis', [cmin cmax], 'colorbar', 'off');
+    % diff_no = get_nested_field(md_ens_1, field) - get_nested_field(md_true_1, field);
+    ens_field = get_nested_field(md_ens_1, field);
+    true_field = get_nested_field(md_true_1, field);
+    if contains(field,'geometry.bed')
+        % diff_no = relative_error(ens_field, true_field);
+        diff_no = signed_log_relerr(ens_field, true_field);
+        % diff_no = relerr_percent_clipped(ens_field, true_field);
+    else
+        diff_no = ens_field - true_field;
+    end
+    maxAbs_no = max(abs(diff_no(:)));
+  
+    % maxAbs_no = prctile(abs(diff_no(:)), 99);
+    plotmodel(md_ens_1,'data',diff_no,'title','(b) No assimilation − True', ...
+        'subplot',[nrows,1,2],'caxis',[-maxAbs_no maxAbs_no],'colorbar','off');
 
-    % (c...): Assimilated snapshots
+    % (c..): Assim - True
     for idx = 1:nk
         k = k_array(idx);
-        label = sprintf('(%c)', 'b' + idx);
-        [md_true, md_nurged, md_ens] = setup_model_states(k, dt, ...
-            model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        [md_true_k, ~, md_ens_k] = setup_model_states(k, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
             md_true, md_nurged, md_ens, md);
-        data_ens = get_nested_field(md_ens, field);
-        plotmodel(md_ens, 'data', data_ens, ...
-            'title', sprintf('%s Assimilated %s (after %.1f years)', label, field_title, round((k-1)*dt)), ...
-            'subplot', [nrows, 1, idx + 2], 'caxis', [cmin cmax], 'colorbar', 'off');
+        ens_field = get_nested_field(md_ens_k, field);
+        true_field = get_nested_field(md_true_k, field);
+        if contains(field,'geometry.bed')
+            diff_k = relative_error(ens_field, true_field);
+            % diff_k = signed_log_relerr(ens_field, true_field);
+            % diff_k = relerr_percent_clipped(ens_field, true_field);
+        else
+            diff_k = ens_field - true_field;
+        end
+        % diff_k = get_nested_field(md_ens_k, field) - get_nested_field(md_true_k, field);
+
+        maxAbs = max(abs(diff_k(:)));
+      
+        % maxAbs = prctile(abs(diff_k(:)), 99);
+        label  = sprintf('(%c)', 'b'+idx);
+        plotmodel(md_ens_k,'data',diff_k, ...
+            'title',sprintf('%s Assimilated − True (after %.1f years)', label, (k-1)*dt), ...
+            'subplot',[nrows,1,idx+2],'caxis',[-maxAbs maxAbs],'colorbar','off');
     end
 
-    % Layout
+    % layout (your adaptive spacing)
     axs = flipud(findall(gcf,'Type','axes'));
-    % --- Adaptive layout scaling ---
-    gap = 0.02;              % small positive gap
-    top = 0.95; bottom = 0.08;
-    available_height = top - bottom - (nrows-1)*gap;
-    height = available_height / nrows;
+    gap = 0.02; top = 0.95; bottom = 0.08;
+    avail = top-bottom - (nrows-1)*gap;
+    height = avail/nrows;
 
-    % if too small (many rows), expand figure height automatically
     if height < 0.05
         fig = gcf;
-        scale_factor = max(1, ceil(0.05 / height));  % ensure visible spacing
-        fig.Position(4) = fig.Position(4) * scale_factor;  % increase figure height
-        height = 0.05;  % set to minimum safe height
+        fig.Position(4) = fig.Position(4) * max(1, ceil(0.05/height));
+        height = 0.05;
     end
-
 
     for i = 1:nrows
         pos = [0.10, bottom+(nrows-i)*(height+gap), 0.70, height];
-        set(axs(i),'Position',pos, ...
-            'FontWeight','bold','LineWidth',1.2,'Box','on', ...
-            'TickDir','out','Layer','top','FontSize',11, ...
-            'TickLength',[0.005 0.005]);
+        set(axs(i),'Position',pos,'FontWeight','bold','LineWidth',1.2,'Box','on', ...
+            'TickDir','out','Layer','top','FontSize',11,'TickLength',[0.005 0.005]);
         ylabel(axs(i),'y (km)','FontWeight','bold');
-        if i < nrows
-            set(axs(i),'XTickLabel',[]);
-        else
-            xlabel(axs(i),'x (km)','FontWeight','bold');
-        end
+        if i < nrows, set(axs(i),'XTickLabel',[]);
+        else, xlabel(axs(i),'x (km)','FontWeight','bold'); end
     end
 
-    % Colorbars
-    % cb1 = colorbar(axs(1), 'Position',[0.83 0.71 0.025 0.16]);
-    % ylabel(cb1,[field_title units_str],'FontSize',12,'FontWeight','bold');
-    % for i = 2:nrows, colormap(axs(i), parula); end
-    % cb2 = colorbar(axs(end), 'Position',[0.83 0.24 0.025 0.45]);
-    % ylabel(cb2,[field_title units_str],'FontSize',12,'FontWeight','bold');
-    % set(gcf,'Color','w');
+    cb1 = colorbar(axs(1), 'Position',[0.83 0.68 0.025 0.16]);
+    ylabel(cb1,[field_title units_str],'FontSize',12,'FontWeight','bold');
+    colormap(axs(1), parula);
+
+    for i = 2:nrows, colormap(axs(i), redblue(256)); end
+    cb2 = colorbar(axs(end), 'Position',[0.83 0.25 0.025 0.40]);
+    % ylabel(cb2,'Difference','FontSize',12,'FontWeight','bold');
+    if contains(field,'geometry.bed')
+        ylabel(cb2,'Relative Error','FontSize',12,'FontWeight','bold');
+    else
+        ylabel(cb2,['Difference' units_str],'FontSize',12,'FontWeight','bold');
+    end
+
+    set(gcf,'Color','w');
+end
+
+function plot_var_evolution(k_array, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+    md_true, md_nurged, md_ens, md, field, field_title, units)
+
+    if nargin < 12, field_title = field; end
+    if nargin < 13, units = ''; end
+    units_str = iff(~isempty(units), [' (' units ')'], '');
+
+    nk    = length(k_array);
+    nrows = 2 + nk;
+
+    figure('Position',[100 100 1000 150 + 150*nrows]); clf;
+
+    % global color limits across (true+ens) at requested steps
+    all_data = [];
+    for k = [k_array(end), k_array]
+        [md_true_tmp, ~, md_ens_tmp] = setup_model_states(k, dt, ...
+            model_true_state, model_nurged_state, ensemble_vec_mean, ...
+            md_true, md_nurged, md_ens, md);
+    
+        tmpT = get_nested_field(md_true_tmp, field);
+        tmpE = get_nested_field(md_ens_tmp,  field);
+    
+        all_data = [all_data; tmpT(:); tmpE(:)];
+    end
+    cmin = min(all_data);
+    cmax = max(all_data);
+    clear all_data
+
+    % (a) True at last snapshot
+    [md_true_last, ~, ~] = setup_model_states(k_array(end), dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md);
+    data_true = get_nested_field(md_true_last, field);
+    plotmodel(md_true_last,'data',data_true, ...
+        'title',sprintf('(a) True %s (after %.1f years)', field_title, (k_array(end)-1)*dt), ...
+        'subplot',[nrows,1,1],'caxis',[cmin cmax],'colorbar','off');
+
+    % (b) No assimilation (k=1) ensemble
+    [~, ~, md_ens_1] = setup_model_states(1, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+        md_true, md_nurged, md_ens, md);
+    data_ens = get_nested_field(md_ens_1, field);
+    plotmodel(md_ens_1,'data',data_ens, ...
+        'title',sprintf('(b) No assimilation %s', field_title), ...
+        'subplot',[nrows,1,2],'caxis',[cmin cmax],'colorbar','off');
+
+    % (c..) Assim snapshots
+    for idx = 1:nk
+        k = k_array(idx);
+        [~, ~, md_ens_k] = setup_model_states(k, dt, model_true_state, model_nurged_state, ensemble_vec_mean, ...
+            md_true, md_nurged, md_ens, md);
+        data_ens = get_nested_field(md_ens_k, field);
+        label = sprintf('(%c)', 'b'+idx);
+        plotmodel(md_ens_k,'data',data_ens, ...
+            'title',sprintf('%s Assimilated %s (after %.1f years)', label, field_title, (k-1)*dt), ...
+            'subplot',[nrows,1,idx+2],'caxis',[cmin cmax],'colorbar','off');
+    end
+
+    % layout (your adaptive spacing)
+    axs = flipud(findall(gcf,'Type','axes'));
+    gap = 0.02; top = 0.95; bottom = 0.08;
+    avail = top-bottom - (nrows-1)*gap;
+    height = avail/nrows;
+
+    if height < 0.05
+        fig = gcf;
+        fig.Position(4) = fig.Position(4) * max(1, ceil(0.05/height));
+        height = 0.05;
+    end
+
+    for i = 1:nrows
+        pos = [0.10, bottom+(nrows-i)*(height+gap), 0.70, height];
+        set(axs(i),'Position',pos,'FontWeight','bold','LineWidth',1.2,'Box','on', ...
+            'TickDir','out','Layer','top','FontSize',11,'TickLength',[0.005 0.005]);
+        ylabel(axs(i),'y (km)','FontWeight','bold');
+        if i < nrows, set(axs(i),'XTickLabel',[]);
+        else, xlabel(axs(i),'x (km)','FontWeight','bold'); end
+    end
 
     for i = 1:nrows, colormap(axs(i), parula); end
     cb = colorbar(axs(end), 'Position',[0.83 0.25 0.025 0.45]);
     ylabel(cb,[field_title units_str],'FontSize',12,'FontWeight','bold');
 
+    set(gcf,'Color','w');
 end
-
 
 function plot_triptych(md_true, md_nurged, md_ens, field, field_title, cmap, units)
 % Compare true, nudged, assimilated, and difference with two separate colorbars
@@ -546,53 +642,55 @@ function plot_triptych(md_true, md_nurged, md_ens, field, field_title, cmap, uni
     data_true   = get_nested_field(md_true, field);
     data_nurged = get_nested_field(md_nurged, field);
     data_ens    = get_nested_field(md_ens, field);
-    diff_data   = data_ens - data_true;
-    % 
-    %     % ---- Compute global colour limits across all requested steps ----
-    % all_data = [];
-    % 
-    % for k = [1, k_array]          % include the true (initial) state
-    %     [md_true_tmp, ~, md_ens_tmp] = setup_model_states(k, dt, ...
-    %         model_true_state, model_nurged_state, ensemble_vec_mean, ...
-    %         md_true, md_nurged, md_ens, md);
-    %     data_tmp = get_nested_field(md_ens_tmp, field);
-    %     all_data = [all_data; data_tmp(:)];
-    %     % Also include true state for diff limits
-    %     data_true_tmp = get_nested_field(md_true_tmp, field);
-    %     all_data = [all_data; data_true_tmp(:)];
-    % end
-    % 
-    % cmin = min(all_data);
-    % cmax = max(all_data);
-    % clear all_data
 
-    % --- Limits ---
-    cmin   = min([data_true(:); data_nurged(:); data_ens(:)]);
-    cmax   = max([data_true(:); data_nurged(:); data_ens(:)]);
-    maxAbs = max(abs(diff_data(:)));
+    % =========================
+    % RELATIVE ERROR
+    % =========================
+    % Stabilizer avoids blowing up where true≈0
+    eps0 = 0.01 * max(abs(data_true(:)));   % 1% of max(true) is a good default
+    if eps0 == 0
+        eps0 = 1; % fallback if true field is exactly zero everywhere
+    end
 
-    figure('Position',[100 100 1000 800]); clf;
+    diff_noassim = (data_nurged - data_true) ./ (abs(data_true) + eps0);
+    diff_assim   = (data_ens    - data_true) ./ (abs(data_true) + eps0);
+
+    % --- Limits for the field panels (True/Wrong/Assim) ---
+    cmin = min([data_true(:); data_nurged(:); data_ens(:)]);
+    cmax = max([data_true(:); data_nurged(:); data_ens(:)]);
+
+    % --- Robust limits for relative-error color axis (avoid 1–2 spikes) ---
+    allerr = [diff_noassim(:); diff_assim(:)];
+    allerr = allerr(isfinite(allerr));
+    if isempty(allerr)
+        maxAbs = 1;
+    else
+        maxAbs = prctile(abs(allerr), 99.5);   % robust: shows structure
+        if maxAbs == 0, maxAbs = 1; end
+    end
+
+    figure('Position',[100 100 1000 820]); clf;
 
     % 1) True
-    plotmodel(md_true,'data',data_true,'title',['True ' field_title], ...
+    plotmodel(md_true,'data',data_true,'title',['(a) True ' field_title], ...
         'subplot',[4,1,1],'caxis',[cmin cmax],'colorbar','off');
 
     % 2) Wrong
-    plotmodel(md_nurged,'data',data_nurged,'title',['Wrong ' field_title], ...
+    plotmodel(md_nurged,'data',data_nurged,'title',['(b) No assimilation ' field_title], ...
         'subplot',[4,1,2],'caxis',[cmin cmax],'colorbar','off');
 
     % 3) Assimilated
-    plotmodel(md_ens,'data',data_ens,'title',['Assimilated ' field_title], ...
+    plotmodel(md_ens,'data',data_ens,'title',['(c) Assimilated ' field_title], ...
         'subplot',[4,1,3],'caxis',[cmin cmax],'colorbar','off');
 
-    % 4) Difference
-    plotmodel(md_ens,'data',diff_data, ...
-        'title',['(Assmilated - True) ' field_title], ...
+    % 4) Relative error (Assim − True)/(|True|+eps0)
+    plotmodel(md_ens,'data',diff_assim, ...
+        'title',['(d) Relative error: (Assim − True) / (|True| + \epsilon)'], ...
         'subplot',[4,1,4],'caxis',[-maxAbs maxAbs],'colorbar','off');
 
     % --- Axes layout ---
     axs = flipud(findall(gcf,'Type','axes'));   % 1..4 top->bottom
-    gap = -0.255; top = 0.94; bottom = 0.08;    % tightened spacing
+    gap = -0.255; top = 0.94; bottom = 0.08;
     height = (top-bottom - 3*gap)/4;
 
     for i = 1:4
@@ -600,328 +698,57 @@ function plot_triptych(md_true, md_nurged, md_ens, field, field_title, cmap, uni
         set(axs(i),'Position',pos, ...
             'FontWeight','bold','LineWidth',1.5,'Box','on', ...
             'TickDir','out','TickLength',[0.005 0.005], ...
-            'Layer','top');
-        ylabel(axs(i),'Y (km)','FontSize',12,'FontWeight','bold');
+            'Layer','top','FontSize',11);
+        ylabel(axs(i),'y (km)','FontSize',12,'FontWeight','bold');
         if i < 4
-            set(axs(i),'XTickLabel',[]);  % only bottom plot shows X
+            set(axs(i),'XTickLabel',[]);
         else
-            xlabel(axs(i),'X (km)','FontSize',12,'FontWeight','bold');
+            xlabel(axs(i),'x (km)','FontSize',12,'FontWeight','bold');
         end
     end
 
-
-    % --- First colorbar (shortened for top 3) ---
-    for i = 1:3, colormap(axs(i), cmap); caxis(axs(i), [cmin cmax]); end
-    cb1 = colorbar(axs(2),'Position',[0.83 0.415 0.025 0.35]); % shorter
+    % --- First colorbar (top 3) ---
+    for i = 1:3
+        colormap(axs(i), cmap);
+        caxis(axs(i), [cmin cmax]);
+    end
+    cb1 = colorbar(axs(2),'Position',[0.83 0.415 0.025 0.35]);
     static_field = regexprep(field_title,'\s+after.*','');
     ylabel(cb1,[static_field units_str],'FontSize',13,'FontWeight','bold');
     cb1.FontSize = 11;
     set(cb1,'Box','on','LineWidth',1.2);
 
-    % --- Second colorbar (shortened for difference) ---
+    % --- Second colorbar (relative error) ---
     ax_diff = axs(4);
     colormap(ax_diff, redblue(256));
     caxis(ax_diff,[-maxAbs maxAbs]);
     pos_diff = get(ax_diff,'Position');
     cb2 = colorbar(ax_diff,'Position',[0.83 pos_diff(2)+0.14 0.025 pos_diff(4)-0.28]);
-    % ylabel(cb2, ['$\mathbf{\Delta}$' static_field units_str], ...
-    %    'Interpreter','latex', ...
-    %    'FontSize',13);
-    ylabel(cb2, ['Difference' units_str], ...
-       'FontSize',13);
+    ylabel(cb2,'Relative error','FontSize',13,'FontWeight','bold');
     cb2.FontSize = 11;
     set(cb2,'Box','on','LineWidth',1.2);
-end
-
-% ---- helpers ----
-function out = get_nested_field(s, field)
-    parts = strsplit(field,'.'); out = s;
-    for i = 1:numel(parts)
-        tok = parts{i};
-        t = regexp(tok,'(.+)\((\d+)\)$','tokens');
-        if ~isempty(t), out = out.(t{1}{1})(str2double(t{1}{2}));
-        else, out = out.(tok);
-        end
-    end
-end
-
-function y = iff(c,a,b), if c, y=a; else, y=b; end, end
-
-function cmap = redblue(n)
-    if nargin<1, n=256; end
-    m = n/2;
-    r=[linspace(0,1,m) ones(1,m)];
-    g=[linspace(0,1,m) linspace(1,0,m)];
-    b=[ones(1,m) linspace(1,0,m)];
-    cmap=[r(:) g(:) b(:)];
-end
-
-function [md_true, md_nurged, md_ens] = setup_model_states(k, dt, model_true_state, model_nurged_state, ensemble_vec_mean, md_true, md_nurged, md_ens, md)
-% =========================================================================
-% setup_model_states
-%
-% Purpose:
-%   Initialize the true, nurged, and ensemble models at time index k.
-%
-% Inputs:
-%   k                  - Time index (integer)
-%   dt                 - Time step (scalar, e.g., 0.15)
-%   model_true_state   - Matrix of true model states [n_state_vars x nt]
-%   model_nurged_state - Matrix of nurged model states [n_state_vars x nt]
-%   ensemble_vec_mean  - Matrix of ensemble mean states [n_state_vars x nt]
-%   md_true, md_nurged, md_ens - Model structures (initialized ISSM models)
-%   md                 - Reference model (for materials, constants)
-%
-% Outputs:
-%   md_true, md_nurged, md_ens - Updated model structures at step k
-%
-% Author:  Brian Kyanjo
-% Date:    2025-11-03
-% =========================================================================
-
-    % --- Basic setup ---
-    global nvar;
-    % nvar =6;
-    hdim = length(model_true_state(:,1)) / nvar;  % Assuming 5 state components
-    di = md.materials.rho_ice / md.materials.rho_water;
-    % hdim = 3347;
-
-    %% === TRUE STATE ===
-    True_thickness = model_true_state(1:hdim, k);
-    % True_base = model_true_state(hdim+1:2*hdim, k);
-    True_surface = model_true_state(hdim+1:2*hdim, k);
-    True_base = True_surface - True_thickness;
-    Vx = model_true_state(2*hdim+1:3*hdim, k);
-    Vy = model_true_state(3*hdim+1:4*hdim, k);
-    Vel = sqrt(Vx.^2 + Vy.^2);
-    True_bed = model_true_state(4*hdim+1:5*hdim, k);
-    True_fcoeff = model_true_state(5*hdim+1:6*hdim, k);
-
-    md_true.geometry.thickness = True_thickness;
-    md_true.geometry.base = True_base;
-    md_true.geometry.surface = True_surface;
-    md_true.initialization.vx  = Vx;
-    md_true.initialization.vy  = Vy;
-    md_true.initialization.vel = Vel;
-    md_true.geometry.bed       = True_bed;
-    md_true.friction.coefficient = True_fcoeff;
-    md_true.mask.ocean_levelset = True_thickness + True_bed / di;
-    % md_true.mask.ocean_levelset = di * md_true.geometry.thickness + md_true.geometry.bed;
-
-
-    %% === NURGED STATE ===
-    nurged_thickness = model_nurged_state(1:hdim, k);
-    % nurged_base = model_nurged_state(hdim+1:2*hdim, k);
-    nurged_surface = model_nurged_state(hdim+1:2*hdim, k);
-    nurged_base = nurged_surface - nurged_thickness;
-    Vx = model_nurged_state(2*hdim+1:3*hdim, k);
-    Vy = model_nurged_state(3*hdim+1:4*hdim, k);
-    Vel = sqrt(Vx.^2 + Vy.^2);
-    nurged_bed = model_nurged_state(4*hdim+1:5*hdim, k);
-    nurged_fcoeff = model_nurged_state(5*hdim+1:6*hdim, k);
-    % nurged_thickness = nurged_surface - nurged_bed;
-
-    md_nurged.geometry.thickness = nurged_thickness;
-    md_nurged.geometry.surface = nurged_surface;
-    md_nurged.initialization.vx  = Vx;
-    md_nurged.initialization.vy  = Vy;
-    md_nurged.initialization.vel = Vel;
-    md_nurged.geometry.bed       = nurged_bed;
-    md_nurged.friction.coefficient = nurged_fcoeff;
-    md_nurged.mask.ocean_levelset = nurged_thickness + nurged_bed / di;
-    % md_nurged.mask.ocean_levelset = di * md_nurged.geometry.thickness + md_nurged.geometry.bed;
-
-    %% === ENSEMBLE MEAN STATE ===
-    ens_thickness = ensemble_vec_mean(1:hdim, k);
-    % ens_base = ensemble_vec_mean(hdim+1:2*hdim, k);
-    ens_surface = ensemble_vec_mean(hdim+1:2*hdim, k);
-    ens_base = ens_surface - ens_thickness;
-    Vx = ensemble_vec_mean(2*hdim+1:3*hdim, k);
-    Vy = ensemble_vec_mean(3*hdim+1:4*hdim, k);
-    Vel = sqrt(Vx.^2 + Vy.^2);
-    ens_bed = ensemble_vec_mean(4*hdim+1:5*hdim, k);
-    ens_fcoeff = ensemble_vec_mean(5*hdim+1:6*hdim, k);
-
-
-    % read friction from temp file
-    % icesee_path='/Users/bkyanjo3/da_project/ICESEE/applications/issm_model/examples/ISMIP_Choi';
-    % % data_path= '_modelrun_datasets';
-    % global data_file_paths;
-    % h5file = fullfile(icesee_path, data_file_paths, sprintf('temp_coefficient_%d.h5', 0));
-    % ens_fcoeff = h5read(h5file, '/coefficient'); ens_fcoeff = ens_fcoeff(k,:)';
-
-
-    % Vx = h5read(h5file, '/Vx');
-    % Vy = h5read(h5file, '/Vy');
-    % Vx = Vx(k,:)'; Vx = Vx(k,:)';
-    % Vel = sqrt(Vx.^2 + Vy.^2);
-
-
-    % ens_thickness = ens_surface - ens_bed;
-
-    md_ens.geometry.thickness = ens_thickness;
-    md_ens.geometry.base = ens_base;
-    md_ens.geometry.surface = ens_surface;
-    md_ens.initialization.vx  = Vx;
-    md_ens.initialization.vy  = Vy;
-    md_ens.initialization.vel = Vel;
-    md_ens.geometry.bed       = ens_bed;
-    md_ens.friction.coefficient = ens_fcoeff;
-    md_ens.mask.ocean_levelset = ens_thickness + ens_bed / di;
-    % md_ens.mask.ocean_levelset = di * md_ens.geometry.thickness + md_ens.geometry.bed;
-
-end
-
-
-function plot_gl_on_bed(md_true, md_nurged, md_ens, t_years)
-% Plot bed + smooth grounding lines (true / wrong / ens) as colored contours.
-
-    % --- Background: bed topography ---
-    % bed_true = md_true.geometry.bed;
-    bed_true = md_true.initialization.vel;
-    cmin = min(bed_true(:));
-    cmax = max(bed_true(:));
-
-    x = md_true.mesh.x(:);
-    y = md_true.mesh.y(:);
-
-    figure('Position',[100 100 1000 280]); clf;
-    plotmodel(md_true,'data',bed_true,...
-        'title',sprintf('Velocity + Grounding lines (t = %.1f years)', t_years), ...
-        'caxis',[cmin cmax],'colorbar','on');
-    hold on;
-
-    % -----------------------------------------------------------------
-    % 1) Build a regular grid for contouring
-    % -----------------------------------------------------------------
-    nx = 400;           % # of points along x (increase for smoother lines)
-    ny = 60;            % # of points along y
-
-    xg = linspace(min(x), max(x), nx);
-    yg = linspace(min(y), max(y), ny);
-    [Xg, Yg] = meshgrid(xg, yg);
-
-    % Ocean level set (φ = 0 is grounding line)
-    phi_true   = md_true.mask.ocean_levelset(:);
-    phi_wrong  = md_nurged.mask.ocean_levelset(:);
-    phi_ens    = md_ens.mask.ocean_levelset(:);
-
-    % Interpolate to grid
-    Phi_true  = griddata(x, y, phi_true,  Xg, Yg, 'linear');
-    Phi_wrong = griddata(x, y, phi_wrong, Xg, Yg, 'linear');
-    Phi_ens   = griddata(x, y, phi_ens,   Xg, Yg, 'linear');
-
-    % -----------------------------------------------------------------
-    % 2) Contour the zero level (grounding line) in different colours
-    % -----------------------------------------------------------------
-    % TRUE GL – thick black
-    [~, h1] = contour(Xg, Yg, Phi_true,  [0 0], 'k-', 'LineWidth', 2.0);
-
-    % NO-ASSIMILATION GL – dashed red
-    [~, h2] = contour(Xg, Yg, Phi_wrong, [0 0], 'r--', 'LineWidth', 1.8);
-
-    % ASSIMILATED GL – solid cyan
-    [~, h3] = contour(Xg, Yg, Phi_ens,   [0 0], 'c-', 'LineWidth', 1.8);
-
-    % -----------------------------------------------------------------
-    % 3) Cosmetics for poster
-    % -----------------------------------------------------------------
-    axis equal tight
-    xlabel('x (m)','FontWeight','bold');
-    ylabel('y (m)','FontWeight','bold');
-
-    set(gca,'FontWeight','bold','LineWidth',1.4,'Box','on', ...
-        'TickDir','out','Layer','top','TickLength',[0.006 0.006]);
-
-    legend([h1(1), h2(1), h3(1)], ...
-           {'True GL','No assimilation GL','Assimilated GL'}, ...
-           'Location','southwest','FontSize',11,'Box','on');
 
     set(gcf,'Color','w');
 end
 
-function plot_velocity_with_gl(md_true, md_nurged, md_ens, time_yrs)
-
-    figure(10); clf
-    plotmodel(md_ens, 'data', md_ens.initialization.vel, ...
-        'title', sprintf('Velocity + Grounding lines (t = %.1f years)', time_yrs), ...
-        'colorbar','on');
-    hold on
-
-    ok_true   = plot_gl_line(md_true,   'k', '-', 2.5);
-    ok_nurg   = plot_gl_line(md_nurged, 'r', '--',2.5);
-    ok_assim  = plot_gl_line(md_ens,    'c', '-', 2.5);
-
-    % legend only for the ones that actually exist
-    ax = gca;
-    h = []; labels = {};
-    if ok_true
-        h(end+1) = plot(ax, NaN, NaN, 'k-',  'LineWidth', 2.5);
-        labels{end+1} = 'True GL';
-    end
-    if ok_nurg
-        h(end+1) = plot(ax, NaN, NaN, 'r--', 'LineWidth', 2.5);
-        labels{end+1} = 'No assimilation GL';
-    end
-    if ok_assim
-        h(end+1) = plot(ax, NaN, NaN, 'c-',  'LineWidth', 2.5);
-        labels{end+1} = 'Assimilated GL';
-    end
-    if ~isempty(h)
-        legend(h, labels, 'Location','southwest');
-    end
-
-    xlabel('x (m)','FontWeight','bold');
-    ylabel('y (m)','FontWeight','bold');
-    set(ax,'FontWeight','bold','LineWidth',1.2,'TickDir','out');
+function rel = relative_error(a, b)
+% Compute (a-b)/max(|b|, eps) safely
+    eps0 = 1e-6 * max(abs(b(:)));   % scale-aware stabilization
+    rel  = (a - b) ./ max(abs(b), eps0);
 end
 
-function ok = plot_gl_line(md, line_color, line_style, lw)
-%PLOT_GL_LINE Plot grounding line from mask.ocean_levelset = 0
-%   ok = plot_gl_line(md, color, style, lw)
-%   returns ok = true if a GL was actually plotted, false otherwise.
-
-    if nargin < 4, lw = 2.0; end
-    if nargin < 3, line_style = '-'; end
-    if nargin < 2, line_color = 'k'; end
-
-    x   = md.mesh.x(:);
-    y   = md.mesh.y(:);
-    phi = md.mask.ocean_levelset(:);
-
-    % quick sanity check: if phi has no sign change, there is no GL
-    if all(phi >= 0) || all(phi <= 0) || all(~isfinite(phi))
-        fprintf('[plot_gl_line] no sign change in ocean_levelset (no GL); skipping.\n');
-        ok = false;
-        return;
-    end
-
-    % --- interpolate to a regular grid for a smooth contour ---
-    Nx = 400; Ny = 60;
-    xg = linspace(min(x), max(x), Nx);
-    yg = linspace(min(y), max(y), Ny);
-    [Xg, Yg] = meshgrid(xg, yg);
-
-    F = scatteredInterpolant(x, y, phi, 'natural', 'nearest');
-    Phig = F(Xg, Yg);
-
-    % check again after interpolation (can become “almost constant”)
-    if max(Phig(:)) * min(Phig(:)) > 0
-        fprintf('[plot_gl_line] interpolated mask has no sign change; skipping.\n');
-        ok = false;
-        return;
-    end
-
-    hold on
-    [C, h] = contour(Xg, Yg, Phig, [0 0], ...
-                     'Color', line_color, ...
-                     'LineStyle', line_style, ...
-                     'LineWidth', lw);
-
-    if isempty(h) || ~isvalid(h)
-        fprintf('[plot_gl_line] contour returned empty handle; skipping.\n');
-        ok = false;
-    else
-        ok = true;
-    end
+function e_log = signed_log_relerr(x, xtrue)
+    eps0  = 1e-3 * prctile(abs(xtrue(:)), 95);   % robust epsilon (NOT max)
+    e     = (x - xtrue) ./ (abs(xtrue) + eps0);
+    e_log = sign(e) .* log10(1 + abs(e));
 end
+
+function e_pct = relerr_percent_clipped(x, xtrue)
+    eps0  = 1e-3 * prctile(abs(xtrue(:)), 95);
+    e_pct = 100 * (x - xtrue) ./ (abs(xtrue) + eps0);
+
+    % robust clip so a few points don’t dominate
+    cap = prctile(abs(e_pct(:)), 99);
+    e_pct = max(min(e_pct, cap), -cap);
+end
+

--- a/applications/issm_model/examples/ISMIP_Choi/run_model.m
+++ b/applications/issm_model/examples/ISMIP_Choi/run_model.m
@@ -35,7 +35,7 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
     ens_id_init = 0;
     h_perturb = 150;
     s_perturb = 25;
-    b_perturb = 50;
+    b_perturb = 60;
     nurged_entries_percentage = 0.25;
 
     output_frequency = 1; % make sure this is set to 1 for coupling with ICESEE
@@ -182,29 +182,26 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
         % % read the friction_bed file
         filename = fullfile(icesee_path, data_path, sprintf('friction_bed_%d.h5', ens_id));
         bed = h5read(filename, '/bed');
-        % coefficient = h5read(filename, '/coefficient');
+        coefficient = h5read(filename, '/coefficient');
 
-        h5file = fullfile(icesee_path,'data/', 'friction_inversion.h5');
-        fcoeff = h5read(h5file, '/friction');
-        vx = h5read(h5file, '/v_x');
-        vy = h5read(h5file, '/v_y');
-        vel = h5read(h5file, '/vel');
-        md.friction.coefficient = friction_ref; %fcoeff;
-        md.initialization.vx = vx;
-        md.initialization.vy = vy;
-        md.initialization.vel = vel;
+        % h5file = fullfile(icesee_path,'data/', 'friction_inversion.h5');
+        % fcoeff = h5read(h5file, '/friction');
+        % vx = h5read(h5file, '/v_x');
+        % vy = h5read(h5file, '/v_y');
+        % vel = h5read(h5file, '/vel');
+
+        md.friction.coefficient = friction_ref + coefficient;
+        md.friction.p=ones(md.mesh.numberofelements,1);
+        md.friction.q=ones(md.mesh.numberofelements,1);
 
         %  update the friction and bed
         % md.friction.coefficient = friction_ref + coefficient;
         % md.friction.coefficient = friction_ref;
 
         bed_err = bed - bed_ref;
-        % md.geometry.bed = bed_ref + bed_err;
-        % md.geometry.base = base_ref + bed_err;
-        % md.geometry.bed = bed_ref + bed - b_perturb*ones(md.mesh.numberofvertices,1);
-        % md.geometry.base = base_ref + bed - b_perturb*ones(md.mesh.numberofvertices,1);
-        md.geometry.bed = bed_ref + bed_err;
-        md.geometry.base = base_ref + bed_err;
+        md.geometry.bed = (bed_ref + bed_err) - b_perturb*randn(md.mesh.numberofvertices, 1);
+        md.geometry.base = (base_ref + bed_err) - b_perturb*randn(md.mesh.numberofvertices, 1);
+        md.geometry.surface = (md.geometry.surface + bed_err) - s_perturb*randn(md.mesh.numberofvertices, 1);
 
         % md.geometry.bed = md.geometry.bed - b_perturb*ones(md.mesh.numberofvertices,1);
         % md.geometry.base = md.geometry.base - b_perturb*ones(md.mesh.numberofvertices,1);
@@ -255,6 +252,8 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
         md.smb.mass_balance=smb*ones(md.mesh.numberofvertices,1);
         md.transient.ismovingfront=0;
         % 
+        md.initialization.pressure       = zeros(md.mesh.numberofvertices, 1);
+        md.masstransport.spcthickness    = NaN * ones(md.mesh.numberofvertices, 1);
         md.basalforcings=linearbasalforcings();
         md.basalforcings.deepwater_melting_rate=deepwater_melting_rate;
         md.basalforcings.groundedice_melting_rate=zeros(md.mesh.numberofvertices,1);
@@ -398,7 +397,7 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
              % % read the friction_bed file
             filename = fullfile(icesee_path, data_path, sprintf('friction_bed_%d.h5', ens_id));
             bed = h5read(filename, '/bed');
-            % coefficient = h5read(filename, '/coefficient');
+            coefficient = h5read(filename, '/coefficient');
 
             % h5file = fullfile(icesee_path,'data/', 'friction_inversion.h5');
             % fcoeff = h5read(h5file, '/friction');
@@ -414,7 +413,8 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
            
 
             %  update the friction and bed
-            md.friction.coefficient = friction_ref;
+            md.friction.coefficient = friction_ref + coefficient;
+            % md.friction.coefficient = friction_ref;
             md.friction.p=ones(md.mesh.numberofelements,1);
             md.friction.q=ones(md.mesh.numberofelements,1);
 
@@ -429,38 +429,14 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
             md.geometry.base = (base_ref + bed_err) - b_perturb*randn(md.mesh.numberofvertices, 1);
             md.geometry.surface = (md.geometry.surface + bed_err) - s_perturb*randn(md.mesh.numberofvertices, 1);
 
-            % nv = md.mesh.numberofvertices;
-            % bed_noise = b_perturb * rand(nv, 1);
-            % md.geometry.bed = bed_ref - bed_noise;
-            % md.geometry.base = base_ref - bed_noise;
-            % md.geometry.bed = bed_ref - bed;
-            % md.geometry.base = base_ref - bed;
-            % base_new = md.geometry.base - bed_noise .* sign(md.geometry.bed);
-            % bed_new = md.geometry.bed - bed_noise .* sign(md.geometry.bed);
+            md.initialization.pressure       = zeros(md.mesh.numberofvertices, 1);
+            md.masstransport.spcthickness    = NaN * ones(md.mesh.numberofvertices, 1);
+            md.transient.ismovingfront=0;
 
-            % md.geometry.bed = bed_new;
-            % md.geometry.base = base_new;
-
-            % md.geometry.bed = bed_ref - b_perturb*ones(md.mesh.numberofvertices,1);
-            % md.geometry.base = base_ref - b_perturb*ones(md.mesh.numberofvertices,1);
-
-            % hdim   = md.mesh.numberofvertices;
-            % n_pert = ceil(nurged_entries_percentage * hdim);
-
-            % thickness_ref = md.geometry.thickness;
-
-            % % Randomly choose which vertices to perturb
-            % perm_idx = randperm(hdim);
-            % pert_idx = perm_idx(1:n_pert);
-
-            % % Zero-mean Gaussian noise with std = h_perturb
-            % h_bump = h_perturb * randn(n_pert,1);
-
-            % % Start from reference thickness
-            % thickness_new = thickness_ref;
-            % thickness_new(pert_idx) = thickness_new(pert_idx) + h_bump;
-
-            % md.geometry.thickness = thickness_new;
+            md.smb.mass_balance=smb*ones(md.mesh.numberofvertices,1);
+            md.basalforcings=linearbasalforcings();
+            md.basalforcings.deepwater_melting_rate=deepwater_melting_rate;
+            md.basalforcings.groundedice_melting_rate=zeros(md.mesh.numberofvertices,1);
 
             md.geometry.thickness = md.geometry.surface - md.geometry.base;
 
@@ -782,23 +758,6 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
             % Subsequent time steps: 
             filename = fullfile(folder, data_fname);
             md = loadmodel(filename);
-            % md = setflowequation(md,'SSA','all');
-            
-            % update geometry
-            % md.geometry.thickness = md.results.TransientSolution(end).Thickness;
-            % md.geometry.surface   = md.results.TransientSolution(end).Surface;
-            % md.geometry.base      = md.results.TransientSolution(end).Base;
-
-            % Update other fields
-            % md.initialization.vx        = md.results.TransientSolution(end).Vx;
-            % md.initialization.vy        = md.results.TransientSolution(end).Vy;
-            % md.initialization.vel       = md.results.TransientSolution(end).Vel;
-            % md.initialization.pressure  = md.results.TransientSolution(end).Pressure;
-            % md.smb.mass_balance         = md.results.TransientSolution(end).SmbMassBalance;
-            % md.mask.ocean_levelset      = md.results.TransientSolution(end).MaskOceanLevelset;
-
-            % md.geometry.bed = md.results.TransientSolution(end).Bed;
-            % md.friction.coefficient = md.results.TransientSolution(end).FrictionCoefficient;
 
             % Load ensemble input from HDF5
             filename = fullfile(icesee_path, data_path, sprintf('ensemble_output_%d.h5', ens_id));
@@ -808,6 +767,7 @@ function run_model(data_fname, ens_id, rank, nprocs, k, dt, tinitial, tfinal)
             md.initialization.vx = h5read(filename, '/Vx');
             md.initialization.vy = h5read(filename, '/Vy');
             md.initialization.vel = sqrt(md.initialization.vx.^2 + md.initialization.vy.^2);
+            md.initialization.pressure=md.materials.rho_ice*md.constants.g*h5read(filename, '/Thickness');
         
             % parameters for bed and friction
             md.geometry.bed = h5read(filename, '/bed');

--- a/src/parallelization/_parallel_i_o.py
+++ b/src/parallelization/_parallel_i_o.py
@@ -289,43 +289,6 @@ def parallel_write_ensemble_scattered(timestep, ensemble_mean, params, ensemble_
                 dset = f['ensemble']
                 ens_mean = f['ensemble_mean']
 
-                # hdim =  model_kwargs.get("nd", params['nd'])//len(model_kwargs.get("all_observed", []))
-
-                # open full ensemble dataset before analysis
-                # inversion_flag = model_kwargs.get("inversion_flag", False)
-                # if inversion_flag:
-                #     print(f"[ICESEE-debug] Rank {rank} performing analysis at time step ..."); exit(0)
-                #     with h5py.File(f'{model_kwargs.get("data_path")}/ensemble_before_analysis_step_{timestep:04d}.h5', 'r') as f_before:
-                #         data_before = f_before['ensemble_before_analysis']
-                #         model_module   = model_kwargs.get("model_module", None)
-                #         print('[ICESEE inversion] - running inverse step to get full state before analysis...')
-                        
-                #         vecs, indx_map, dim_per_proc = icesee_get_index(**model_kwargs)
-                        
-                #         for ii, key in enumerate (model_kwargs.get("vec_inputs_new", [])):
-                #             # print('key:\n', key)
-                #             start = ii*hdim
-                #             end = start + hdim      
-                #             data_before[indx_map[key], :] = recvbuf[start:end, :]
-                #             # data_before[indx_map[key], :] = recvbuf[indx_map[key], :]
-                        
-                #         data = model_module.inverse_step_single(ensemble=data_before, **model_kwargs)
-                #         for key, value in data.items():
-                #             data_before[indx_map[key], :] = value
-
-                #         # Build global indices in correct full-state order
-                #         # obs_indices = np.concatenate([indx_map[key] for key in model_kwargs.get("all_observed", [])])
-
-                #         # # (nd_new, Nens) must match recvbuf
-                #         # data_before[obs_indices, :] = recvbuf.copy()
-
-
-                #     # Write gathered data
-                #     dset[:, :, timestep] = data_before
-                #     ens_mean[:, timestep] = np.mean(data_before, axis=1)
-                # else:
-                    # Write gathered data
-
                 # apply a relaxation factor to bed
                 vecs, indx_map, dim_per_proc = icesee_get_index(**model_kwargs)
                 thickness_idx = 0; surface_idx = 0; bed_idx = 0

--- a/src/run_model_da/icesee_da_partial_parallel.py
+++ b/src/run_model_da/icesee_da_partial_parallel.py
@@ -163,6 +163,7 @@ def icesee_model_data_assimilation_partial_parallel(**model_kwargs):
         time_generation_true_and_wrong_state = MPI.Wtime() - time_generation_true_and_wrong_state
 
         comm_world.Barrier()
+        # exit(0);
 
         # --- Generate the Synthetic ObservationsObservations ---------------------------------------------------
         # --- time generation of synthetic observations ---


### PR DESCRIPTION
This pull request introduces several updates to the ISSM-ENKF example and supporting scripts, focusing on improving the realism and flexibility of the ensemble initialization, model perturbations, and parameter settings. The changes impact both the Python and MATLAB components, as well as the YAML configuration, to better support data assimilation experiments.

**Key changes include:**

**1. Model initialization and perturbation improvements**
- The ensemble initialization and model run scripts now apply random Gaussian perturbations to bed, base, and surface geometries, as well as update friction coefficients using ensemble-specific data, enhancing the realism of the ensemble spread and the data assimilation process. (`run_model.m`, `_issm_enkf.py`) [[1]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L185-R204) [[2]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L432-R439) [[3]](diffhunk://#diff-0b655b88e94ff13e29f9b6b964d0140ca83cbc9dadbfbb4e0e7f60d0d51515e7L223-R224) [[4]](diffhunk://#diff-0b655b88e94ff13e29f9b6b964d0140ca83cbc9dadbfbb4e0e7f60d0d51515e7L243-R244) [[5]](diffhunk://#diff-0b655b88e94ff13e29f9b6b964d0140ca83cbc9dadbfbb4e0e7f60d0d51515e7L411-R412) [[6]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L401-R400) [[7]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L417-R417)

**2. Parameter tuning and configuration updates**
- The YAML configuration file has been updated to adjust observation time limits, initial ensemble spread, observation and process noise standard deviations, and length scales for covariance, reflecting new experimental settings for improved performance. (`params.yaml`) [[1]](diffhunk://#diff-c4f9a8cba5cd74522bd2ab02a94c320a0f3b9fc887d2ae22436f2bf6319f7258L29-R36) [[2]](diffhunk://#diff-c4f9a8cba5cd74522bd2ab02a94c320a0f3b9fc887d2ae22436f2bf6319f7258L59-R63)
- The magnitude of bed perturbations in the MATLAB model has been increased to better represent uncertainty. (`run_model.m`)

**3. Output and I/O enhancements**
- Additional model fields such as `pressure` and `spcthickness` are now initialized for each run, ensuring all necessary variables are available for downstream processing and analysis. (`run_model.m`) [[1]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6R255-R256) [[2]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L432-R439) [[3]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6R770)
- The friction coefficient is now consistently read from the ensemble HDF5 files and applied in the model, replacing previous hardcoded or reference-only assignments. (`run_model.m`) [[1]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L185-R204) [[2]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L401-R400) [[3]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L417-R417)

**4. Code cleanup and debugging**
- Large blocks of commented-out or obsolete code have been removed or further commented, clarifying the workflow and reducing clutter in both Python and MATLAB scripts. (`run_model.m`, `_parallel_i_o.py`) [[1]](diffhunk://#diff-f6dba0bfb03ce02aa1602dc9decd26cb9837bbf8a0ca2ade3c60121ab321b3d6L785-L801) [[2]](diffhunk://#diff-d9192967ace5ea9e71adaa122d10bccb4f805644260824df96c34c6d602e04a4L292-L328)
- A debugging exit statement was added (commented) to facilitate troubleshooting in the data assimilation pipeline. (`icesee_da_partial_parallel.py`)