### PR TITLE
solved issue for when Lx/Ly is not provided yet its needed for error …

### DIFF
--- a/src/run_model_da/_error_generation.py
+++ b/src/run_model_da/_error_generation.py
@@ -880,6 +880,9 @@ def sample_periodic_exp_cov(hdim: int, sigma2: float, Lx: float, rng=None):
         rng = np.random.default_rng()
 
     n = int(hdim)
+    if Lx is None:
+        Lx = float(n)
+        
     if n <= 0:
         raise ValueError("hdim must be positive")
     if Lx <= 0:


### PR DESCRIPTION
This pull request makes a small but important change to the `sample_periodic_exp_cov` function in `src/run_model_da/_error_generation.py`. The change ensures that if the `Lx` parameter is not provided (`None`), it defaults to the value of `hdim`, improving the function's robustness.

* Defaulting behavior: If `Lx` is `None`, it is now set to `float(hdim)` within the function.…generation